### PR TITLE
Fix admin feature response

### DIFF
--- a/server.js
+++ b/server.js
@@ -150,7 +150,7 @@ app.post('/api/login', async (req, res) => {
         
         if (match) {
             req.session.user = { username: user.username };
-            return res.json({ success: true, message: 'Login successful' });
+            return res.json({ success: true, message: 'Login successful', isAdmin: !!user.isAdmin });
         }
     }
     // If user not found or password doesn't match
@@ -186,7 +186,8 @@ app.post('/api/logout', (req, res) => {
 
 app.get('/api/auth/status', (req, res) => {
     if (req.session.user) {
-        res.json({ authenticated: true, username: req.session.user.username });
+        const user = users[req.session.user.username];
+        res.json({ authenticated: true, username: req.session.user.username, isAdmin: !!(user && user.isAdmin) });
     } else {
         res.json({ authenticated: false });
     }


### PR DESCRIPTION
## Summary
- include `isAdmin` in login response
- expose `isAdmin` in `/api/auth/status`

## Testing
- `node Jp-Server/server.js > /tmp/server.log 2>&1 &` *(fails: address in use)*
- `curl -i -c cookies.txt -H "Content-Type: application/json" -d '{"username":"TestAdmin","password":"password"}' http://localhost:3000/api/login`
- `curl -b cookies.txt http://localhost:3000/api/auth/status`


------
https://chatgpt.com/codex/tasks/task_e_6857a20c678483328e912a2a35903d52