### PR TITLE
Separate login page

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -35,8 +35,22 @@
         function toggleDarkMode() { appData.settings.darkMode = !appData.settings.darkMode; applyDarkMode(appData.settings.darkMode); saveData(); renderView(); }
         
         // --- Authentication & App Lifecycle ---
-        async function checkAuthStatus() { try { const response = await fetch(`${API_BASE}/api/auth/status`, { credentials: 'include' }); const data = await response.json(); if (data.authenticated) { isAuthenticated = true; document.getElementById('user-info').textContent = `Welcome, ${data.username}`; showApp(); } else { isAuthenticated = false; showLogin(); } } catch (error) { showLogin(); } }
-        async function handleLogin(event) { event.preventDefault(); const username = document.getElementById('username').value; const password = document.getElementById('password').value; const submitBtn = document.getElementById('login-submit-btn'); const errorDiv = document.getElementById('login-error'); submitBtn.textContent = 'Logging in...'; submitBtn.disabled = true; errorDiv.style.display = 'none'; try { const response = await fetch(`${API_BASE}/api/login`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'include', body: JSON.stringify({ username, password }) }); const data = await response.json(); if (data.success) { isAuthenticated = true; document.getElementById('user-info').textContent = `Welcome, ${username}`; showDataStatus('Login successful!', false); showApp(); } else { errorDiv.textContent = data.message || 'Invalid credentials'; errorDiv.style.display = 'block'; } } catch (error) { errorDiv.textContent = 'Login failed. Please try again.'; errorDiv.style.display = 'block'; } finally { submitBtn.textContent = 'Login'; submitBtn.disabled = false; } }
+        async function checkAuthStatus() {
+            try {
+                const response = await fetch(`${API_BASE}/api/auth/status`, { credentials: 'include' });
+                const data = await response.json();
+                if (data.authenticated) {
+                    isAuthenticated = true;
+                    document.getElementById('user-info').textContent = `Welcome, ${data.username}`;
+                    showApp();
+                } else {
+                    isAuthenticated = false;
+                    showLogin();
+                }
+            } catch (error) {
+                showLogin();
+            }
+        }
 
         async function logout() {
             try {
@@ -53,8 +67,14 @@
 
         async function logout() { try { await fetch(`${API_BASE}/api/logout`, { method: 'POST', credentials: 'include' }); isAuthenticated = false; document.getElementById('user-info').textContent = ''; showDataStatus('Logged out', false); showLogin(); } catch (error) { console.error('Logout failed:', error); } }
 
-        function showLogin() { document.getElementById('login-page').style.display = 'block'; document.getElementById('app-content').style.display = 'none'; document.querySelector('.header-sticky-container').style.display = 'none'; document.getElementById('username').value = ''; document.getElementById('password').value = ''; document.getElementById('login-error').style.display = 'none'; }
-        function showApp() { document.getElementById('login-page').style.display = 'none'; document.getElementById('app-content').style.display = 'block'; document.querySelector('.header-sticky-container').style.display = 'block'; initializeApp(); }
+        function showLogin() {
+            window.location.href = 'login.html';
+        }
+        function showApp() {
+            document.getElementById('app-content').style.display = 'block';
+            document.querySelector('.header-sticky-container').style.display = 'block';
+            initializeApp();
+        }
         document.addEventListener('DOMContentLoaded', function() {
             const mobileMenuBtn = document.getElementById('mobile-menu-btn');
             const mobileNavOverlay = document.getElementById('mobile-nav-overlay');

--- a/public/index.html
+++ b/public/index.html
@@ -213,8 +213,6 @@
         .data-status.show, .connection-status.show { opacity: 1; transform: translateX(-50%) translateY(0); }
         .data-status.error, .connection-status { background: var(--danger-color); } .data-status.loading { background: var(--warning-color); }
         
-        /* --- Login Page --- */
-        #login-page { animation: fadeInUp 0.5s ease-out; } #login-error { color: var(--danger-color); }
         
         /* --- Responsive Design --- */
         @media (max-width: 768px) {
@@ -248,7 +246,6 @@
     </div>
     <div id="mobile-nav-overlay"><div class="mobile-nav-links"></div></div>
     <main class="container">
-        <div id="login-page" class="card" style="max-width: 400px; margin: 2rem auto; display: none;"><h2 style="text-align: center; margin-bottom: 2rem;">🔒 Secure Access</h2><form id="login-form" onsubmit="handleLogin(event)"><div class="form-group"><label class="form-label">Username</label><input type="text" id="username" class="form-input" required></div><div class="form-group"><label class="form-label">Password</label><input type="password" id="password" class="form-input" required></div><button type="submit" class="btn btn-primary" style="width: 100%;" id="login-submit-btn">Login</button><div id="login-error" style="text-align: center; margin-top: 1rem; display: none;"></div><p style="text-align: center; margin-top: 1rem;"><a href="register.html">Create account</a></p></form></div>
         <div id="app-content" style="display: none;"><div class="card"><div class="text-center" style="padding: 2rem;"><p>Loading...</p></div></div></div>
     </main>
     <script>window.INIT_VIEW="dashboard";</script>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 400px; margin: 2rem auto; }
+        label { display: block; margin-top: 1rem; }
+        input { width: 100%; padding: 0.5rem; margin-top: 0.25rem; }
+        button { margin-top: 1rem; padding: 0.5rem 1rem; width: 100%; }
+        #error { color: red; margin-top: 1rem; }
+    </style>
+</head>
+<body>
+    <h2>🔒 Secure Access</h2>
+    <form id="login-form">
+        <label>Username
+            <input type="text" id="username" required>
+        </label>
+        <label>Password
+            <input type="password" id="password" required>
+        </label>
+        <button type="submit" id="login-submit-btn">Login</button>
+        <div id="error"></div>
+        <p style="text-align:center;margin-top:1rem;"><a href="register.html">Create account</a></p>
+    </form>
+    <script>
+        document.getElementById('login-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const username = document.getElementById('username').value;
+            const password = document.getElementById('password').value;
+            const btn = document.getElementById('login-submit-btn');
+            const err = document.getElementById('error');
+            btn.disabled = true;
+            btn.textContent = 'Logging in...';
+            err.textContent = '';
+            try {
+                const res = await fetch('/api/login', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify({ username, password })
+                });
+                const data = await res.json();
+                if (data.success) {
+                    window.location.href = 'index.html';
+                } else {
+                    err.textContent = data.message || 'Invalid credentials';
+                }
+            } catch (e2) {
+                err.textContent = 'Login failed';
+            } finally {
+                btn.disabled = false;
+                btn.textContent = 'Login';
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove inline login form from `index.html`
- redirect to standalone `login.html` when unauthenticated
- update app script to handle redirect
- add new `public/login.html` page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857a28e32608332bf2656fdc1a2e7fa