### PR TITLE
Fix mobile calendar grid overflow

### DIFF
--- a/public/analytics.html
+++ b/public/analytics.html
@@ -170,7 +170,7 @@
         .desktop-calendar { display: block; } .mobile-calendar { display: none; }
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
-        .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
+        .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
         .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }

--- a/public/calendar.html
+++ b/public/calendar.html
@@ -170,7 +170,7 @@
         .desktop-calendar { display: block; } .mobile-calendar { display: none; }
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
-        .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
+        .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
         .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }

--- a/public/expenses.html
+++ b/public/expenses.html
@@ -170,7 +170,7 @@
         .desktop-calendar { display: block; } .mobile-calendar { display: none; }
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
-        .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
+        .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
         .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }

--- a/public/income.html
+++ b/public/income.html
@@ -170,7 +170,7 @@
         .desktop-calendar { display: block; } .mobile-calendar { display: none; }
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
-        .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
+        .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
         .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }

--- a/public/index.html
+++ b/public/index.html
@@ -170,7 +170,7 @@
         .desktop-calendar { display: block; } .mobile-calendar { display: none; }
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
-        .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
+        .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
         .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }

--- a/public/settings.html
+++ b/public/settings.html
@@ -170,7 +170,7 @@
         .desktop-calendar { display: block; } .mobile-calendar { display: none; }
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
-        .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
+        .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
         .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }

--- a/public/suggestions.html
+++ b/public/suggestions.html
@@ -170,7 +170,7 @@
         .desktop-calendar { display: block; } .mobile-calendar { display: none; }
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
-        .calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
+        .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
         .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }


### PR DESCRIPTION
## Summary
- allow calendar grid columns to shrink to mobile width

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860a594c53083329348725792d30939