### PR TITLE
Fix stretched mobile calendar

### DIFF
--- a/public/calendar.html
+++ b/public/calendar.html
@@ -171,7 +171,7 @@
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
         .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
-        .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
+        .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; aspect-ratio: 1/1; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }
         body.dark-mode .calendar-day.selected { background-color: #00417d; }
@@ -234,6 +234,7 @@
             .grid-2 { grid-template-columns: 1fr; }
             .calendar-week-grid { display: block; border: none; }
             .calendar-week-day { border: none; border-bottom: 1px solid var(--border-color); }
+            .calendar-day { min-height: 60px; }
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- tweak calendar day grid CSS so days stay square
- reduce min-height on mobile to keep calendar compact

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a24e7b4708332a5727e6b16a99e6b