### PR TITLE
Fix mobile overflow on calendar

### DIFF
--- a/public/analytics.html
+++ b/public/analytics.html
@@ -179,7 +179,17 @@
         .calendar-day.other-month { color: var(--text-color-tertiary); }
         .day-number { font-size: 0.875rem; font-weight: 500; margin-bottom: 0.25rem; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; border-radius: 50%; }
         .day-events { display: flex; flex-direction: column; gap: 2px; }
-        .event-badge { font-size: 0.75rem; padding: 2px 6px; border-radius: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 500; }
+        .event-badge {
+            font-size: 0.75rem;
+            padding: 2px 6px;
+            border-radius: 4px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-weight: 500;
+            display: block;
+            max-width: 100%;
+        }
         .event-income { background-color: #e1f5e8; color: #1f8a44; } .event-work { background-color: #e0f0ff; color: #0056b3; } .event-vacation { background-color: #f3e8ff; color: #6a00de; } .event-sick { background-color: #ffeaea; color: #c82121; }
         body.dark-mode .event-income { background-color: #0c2e17; color: #6ce98f; } body.dark-mode .event-work { background-color: #002c52; color: #8ecaff; } body.dark-mode .event-vacation { background-color: #3b007d; color: #e1c0ff; } body.dark-mode .event-sick { background-color: #5c0f0f; color: #ffb1ab; }
 

--- a/public/calendar.html
+++ b/public/calendar.html
@@ -62,6 +62,7 @@
             min-height: 100vh;
             display: flex;
             flex-direction: column;
+            overflow-x: hidden;
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
             transition: background-color var(--transition-speed), color var(--transition-speed);
@@ -179,7 +180,17 @@
         .calendar-day.other-month { color: var(--text-color-tertiary); }
         .day-number { font-size: 0.875rem; font-weight: 500; margin-bottom: 0.25rem; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; border-radius: 50%; }
         .day-events { display: flex; flex-direction: column; gap: 2px; }
-        .event-badge { font-size: 0.75rem; padding: 2px 6px; border-radius: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 500; }
+        .event-badge {
+            font-size: 0.75rem;
+            padding: 2px 6px;
+            border-radius: 4px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-weight: 500;
+            display: block;
+            max-width: 100%;
+        }
         .event-income { background-color: #e1f5e8; color: #1f8a44; } .event-work { background-color: #e0f0ff; color: #0056b3; } .event-vacation { background-color: #f3e8ff; color: #6a00de; } .event-sick { background-color: #ffeaea; color: #c82121; }
         body.dark-mode .event-income { background-color: #0c2e17; color: #6ce98f; } body.dark-mode .event-work { background-color: #002c52; color: #8ecaff; } body.dark-mode .event-vacation { background-color: #3b007d; color: #e1c0ff; } body.dark-mode .event-sick { background-color: #5c0f0f; color: #ffb1ab; }
 

--- a/public/expenses.html
+++ b/public/expenses.html
@@ -179,7 +179,17 @@
         .calendar-day.other-month { color: var(--text-color-tertiary); }
         .day-number { font-size: 0.875rem; font-weight: 500; margin-bottom: 0.25rem; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; border-radius: 50%; }
         .day-events { display: flex; flex-direction: column; gap: 2px; }
-        .event-badge { font-size: 0.75rem; padding: 2px 6px; border-radius: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 500; }
+        .event-badge {
+            font-size: 0.75rem;
+            padding: 2px 6px;
+            border-radius: 4px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-weight: 500;
+            display: block;
+            max-width: 100%;
+        }
         .event-income { background-color: #e1f5e8; color: #1f8a44; } .event-work { background-color: #e0f0ff; color: #0056b3; } .event-vacation { background-color: #f3e8ff; color: #6a00de; } .event-sick { background-color: #ffeaea; color: #c82121; }
         body.dark-mode .event-income { background-color: #0c2e17; color: #6ce98f; } body.dark-mode .event-work { background-color: #002c52; color: #8ecaff; } body.dark-mode .event-vacation { background-color: #3b007d; color: #e1c0ff; } body.dark-mode .event-sick { background-color: #5c0f0f; color: #ffb1ab; }
 

--- a/public/income.html
+++ b/public/income.html
@@ -179,7 +179,17 @@
         .calendar-day.other-month { color: var(--text-color-tertiary); }
         .day-number { font-size: 0.875rem; font-weight: 500; margin-bottom: 0.25rem; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; border-radius: 50%; }
         .day-events { display: flex; flex-direction: column; gap: 2px; }
-        .event-badge { font-size: 0.75rem; padding: 2px 6px; border-radius: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 500; }
+        .event-badge {
+            font-size: 0.75rem;
+            padding: 2px 6px;
+            border-radius: 4px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-weight: 500;
+            display: block;
+            max-width: 100%;
+        }
         .event-income { background-color: #e1f5e8; color: #1f8a44; } .event-work { background-color: #e0f0ff; color: #0056b3; } .event-vacation { background-color: #f3e8ff; color: #6a00de; } .event-sick { background-color: #ffeaea; color: #c82121; }
         body.dark-mode .event-income { background-color: #0c2e17; color: #6ce98f; } body.dark-mode .event-work { background-color: #002c52; color: #8ecaff; } body.dark-mode .event-vacation { background-color: #3b007d; color: #e1c0ff; } body.dark-mode .event-sick { background-color: #5c0f0f; color: #ffb1ab; }
 

--- a/public/index.html
+++ b/public/index.html
@@ -179,7 +179,17 @@
         .calendar-day.other-month { color: var(--text-color-tertiary); }
         .day-number { font-size: 0.875rem; font-weight: 500; margin-bottom: 0.25rem; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; border-radius: 50%; }
         .day-events { display: flex; flex-direction: column; gap: 2px; }
-        .event-badge { font-size: 0.75rem; padding: 2px 6px; border-radius: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 500; }
+        .event-badge {
+            font-size: 0.75rem;
+            padding: 2px 6px;
+            border-radius: 4px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-weight: 500;
+            display: block;
+            max-width: 100%;
+        }
         .event-income { background-color: #e1f5e8; color: #1f8a44; } .event-work { background-color: #e0f0ff; color: #0056b3; } .event-vacation { background-color: #f3e8ff; color: #6a00de; } .event-sick { background-color: #ffeaea; color: #c82121; }
         body.dark-mode .event-income { background-color: #0c2e17; color: #6ce98f; } body.dark-mode .event-work { background-color: #002c52; color: #8ecaff; } body.dark-mode .event-vacation { background-color: #3b007d; color: #e1c0ff; } body.dark-mode .event-sick { background-color: #5c0f0f; color: #ffb1ab; }
 

--- a/public/settings.html
+++ b/public/settings.html
@@ -179,7 +179,17 @@
         .calendar-day.other-month { color: var(--text-color-tertiary); }
         .day-number { font-size: 0.875rem; font-weight: 500; margin-bottom: 0.25rem; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; border-radius: 50%; }
         .day-events { display: flex; flex-direction: column; gap: 2px; }
-        .event-badge { font-size: 0.75rem; padding: 2px 6px; border-radius: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 500; }
+        .event-badge {
+            font-size: 0.75rem;
+            padding: 2px 6px;
+            border-radius: 4px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-weight: 500;
+            display: block;
+            max-width: 100%;
+        }
         .event-income { background-color: #e1f5e8; color: #1f8a44; } .event-work { background-color: #e0f0ff; color: #0056b3; } .event-vacation { background-color: #f3e8ff; color: #6a00de; } .event-sick { background-color: #ffeaea; color: #c82121; }
         body.dark-mode .event-income { background-color: #0c2e17; color: #6ce98f; } body.dark-mode .event-work { background-color: #002c52; color: #8ecaff; } body.dark-mode .event-vacation { background-color: #3b007d; color: #e1c0ff; } body.dark-mode .event-sick { background-color: #5c0f0f; color: #ffb1ab; }
 

--- a/public/suggestions.html
+++ b/public/suggestions.html
@@ -179,7 +179,17 @@
         .calendar-day.other-month { color: var(--text-color-tertiary); }
         .day-number { font-size: 0.875rem; font-weight: 500; margin-bottom: 0.25rem; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; border-radius: 50%; }
         .day-events { display: flex; flex-direction: column; gap: 2px; }
-        .event-badge { font-size: 0.75rem; padding: 2px 6px; border-radius: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 500; }
+        .event-badge {
+            font-size: 0.75rem;
+            padding: 2px 6px;
+            border-radius: 4px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-weight: 500;
+            display: block;
+            max-width: 100%;
+        }
         .event-income { background-color: #e1f5e8; color: #1f8a44; } .event-work { background-color: #e0f0ff; color: #0056b3; } .event-vacation { background-color: #f3e8ff; color: #6a00de; } .event-sick { background-color: #ffeaea; color: #c82121; }
         body.dark-mode .event-income { background-color: #0c2e17; color: #6ce98f; } body.dark-mode .event-work { background-color: #002c52; color: #8ecaff; } body.dark-mode .event-vacation { background-color: #3b007d; color: #e1c0ff; } body.dark-mode .event-sick { background-color: #5c0f0f; color: #ffb1ab; }
 


### PR DESCRIPTION
## Summary
- prevent horizontal overflow on mobile calendar page
- ensure event badges don't stretch calendar cells

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_686c9de5a19c8332b193d2cd44d34fe1