### PR TITLE
Fix calendar day box sizing

### DIFF
--- a/public/analytics.html
+++ b/public/analytics.html
@@ -171,7 +171,7 @@
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
         .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
-        .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
+        .calendar-day { background: var(--card-background); padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; aspect-ratio: 1/1; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }
         body.dark-mode .calendar-day.selected { background-color: #00417d; }

--- a/public/calendar.html
+++ b/public/calendar.html
@@ -172,7 +172,7 @@
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
         .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
-        .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; aspect-ratio: 1/1; }
+        .calendar-day { background: var(--card-background); padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; aspect-ratio: 1/1; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }
         body.dark-mode .calendar-day.selected { background-color: #00417d; }
@@ -245,7 +245,7 @@
             .grid-2 { grid-template-columns: 1fr; }
             .calendar-week-grid { display: block; border: none; }
             .calendar-week-day { border: none; border-bottom: 1px solid var(--border-color); }
-            .calendar-day { min-height: 60px; }
+            .calendar-day { aspect-ratio: 1/1; }
         }
     </style>
 </head>

--- a/public/expenses.html
+++ b/public/expenses.html
@@ -171,7 +171,7 @@
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
         .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
-        .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
+        .calendar-day { background: var(--card-background); padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; aspect-ratio: 1/1; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }
         body.dark-mode .calendar-day.selected { background-color: #00417d; }

--- a/public/income.html
+++ b/public/income.html
@@ -171,7 +171,7 @@
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
         .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
-        .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
+        .calendar-day { background: var(--card-background); padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; aspect-ratio: 1/1; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }
         body.dark-mode .calendar-day.selected { background-color: #00417d; }

--- a/public/index.html
+++ b/public/index.html
@@ -171,7 +171,7 @@
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
         .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
-        .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
+        .calendar-day { background: var(--card-background); padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; aspect-ratio: 1/1; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }
         body.dark-mode .calendar-day.selected { background-color: #00417d; }

--- a/public/settings.html
+++ b/public/settings.html
@@ -171,7 +171,7 @@
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
         .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
-        .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
+        .calendar-day { background: var(--card-background); padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; aspect-ratio: 1/1; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }
         body.dark-mode .calendar-day.selected { background-color: #00417d; }

--- a/public/suggestions.html
+++ b/public/suggestions.html
@@ -171,7 +171,7 @@
         .calendar-header-controls { display: flex; justify-content: space-between; align-items: center; margin: 1rem 0; gap: 0.5rem; }
         .calendar-days-header { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; margin-bottom: 0.5rem; text-align: center; font-size: 0.875rem; color: var(--text-color-secondary); }
         .calendar-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 1px; background-color: var(--border-color); border: 1px solid var(--border-color); border-radius: var(--border-radius-medium); overflow: hidden; }
-        .calendar-day { background: var(--card-background); min-height: 110px; padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; }
+        .calendar-day { background: var(--card-background); padding: 0.5rem; cursor: pointer; transition: background-color 0.2s; position: relative; aspect-ratio: 1/1; }
         .calendar-day:hover { background-color: var(--background-color-light); }
         .calendar-day.selected { background-color: #e5f2ff; box-shadow: inset 0 0 0 2px var(--primary-color); }
         body.dark-mode .calendar-day.selected { background-color: #00417d; }


### PR DESCRIPTION
## Summary
- keep calendar day height equal to width with CSS `aspect-ratio`
- remove min-height rules so squares don't stretch

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ca509672083329e566ff14913f357